### PR TITLE
added a recognosable User-Agent string inside the Android in-app browser

### DIFF
--- a/android/app/src/main/java/be/desmottes/mangerveggie/MainActivity.java
+++ b/android/app/src/main/java/be/desmottes/mangerveggie/MainActivity.java
@@ -49,7 +49,7 @@ public class MainActivity extends Activity {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT) {
             webSettings.setDatabasePath("/data/data/" + webView.getContext().getPackageName() + "/databases/");
         }
-
+        webSettings.setUserAgentString(webSettings.getUserAgentString() + " " + getString(R.string.app_name));
 
         webView.setWebChromeClient(new WebChromeClient() {
             public void onGeolocationPermissionsShowPrompt(String origin, GeolocationPermissions.Callback callback) {

--- a/restaurant/static/js/utils.js
+++ b/restaurant/static/js/utils.js
@@ -9,3 +9,21 @@ function tags_to_color(tags) {
     return 'blue'
   }
 }
+
+/* add a link inside a menu either:
+ - to the about page in order to explain how to add a shortcut (iPhone & co)
+ - to the Android application, if the browser is using Android and if not already using the application */
+function add_mobile_link() {
+  // https://stackoverflow.com/questions/3514784/
+  // https://stackoverflow.com/questions/6031412
+  if(navigator.userAgent.toLowerCase().indexOf("android") > -1) {
+    // cf app_name inside android/app/src/main/res/values/strings.xml
+    if(navigator.userAgent.indexOf("Manger Veggie") > -1) {
+      return;
+    }
+    $('<li><a href="https://play.google.com/store/apps/details?id=be.desmottes.mangerveggie">Installer l\'application pour Android</a></li>').prependTo(".navbar-right");
+  }
+  else if(/webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ) {
+    $('<li><a href="/about#mobile_shortcut">Ajouter un raccourci vers vegOresto</a></li>').prependTo(".navbar-right");
+  }
+}


### PR DESCRIPTION
added add_mobile_link() which use the specific UA string in order to add
a specific menu links for non-Android and non-Android-app visitors