### PR TITLE
android: fixed errors reported in the lint test

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "be.desmottes.mangerveggie"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 23
         versionCode 2
         versionName "1.1"
@@ -17,6 +17,11 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    lintOptions {
+        disable 'SetJavaScriptEnabled'
+    }
+
 }
 
 dependencies {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="vegout.desmottes.be.vegout" >
 
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+
     <application
         android:allowBackup="true"
         android:icon="@drawable/mv_icon"
@@ -17,7 +21,4 @@
             </intent-filter>
         </activity>
     </application>
-    <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 </manifest>

--- a/android/app/src/main/res/menu/menu_main.xml
+++ b/android/app/src/main/res/menu/menu_main.xml
@@ -1,5 +1,6 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools" tools:context=".MainActivity">
+      xmlns:mangerveggie="http://schemas.android.com/apk/res-auto"
+      xmlns:tools="http://schemas.android.com/tools" tools:context=".MainActivity">
     <item android:id="@+id/action_settings" android:title="@string/action_settings"
-        android:orderInCategory="100" android:showAsAction="never" />
+        android:orderInCategory="100" mangerveggie:showAsAction="never" />
 </menu>


### PR DESCRIPTION
- showAsAction namespace
- minSdkVersion == 14 since parent="android:Theme.Holo.Light.DarkActionBar"
  (src/main/res/values/styles.xml) is not available before

and a couple of lint warnings:
- SetJavaScriptEnabled is legitimate
- <uses-permission> before <application> in app/src/main/AndroidManifest.xml