### PR TITLE
vegoresto.fr has finally gone HTTPS

### DIFF
--- a/restaurant/models.py
+++ b/restaurant/models.py
@@ -9,7 +9,7 @@ from geopy.geocoders import ArcGIS, OpenMapQuest, GoogleV3, Nominatim, GeocoderD
 
 GEOCODERS = [Nominatim, GoogleV3, ArcGIS, OpenMapQuest, GeocoderDotUS]
 
-VEGO_RESTO_URL = "http://vegoresto.fr/resto/%s"
+VEGO_RESTO_URL = "https://vegoresto.fr/%s"
 
 class Restaurant(models.Model):
     vegoresto_id = models.BigIntegerField(unique=True)

--- a/restaurant/templates/about.haml
+++ b/restaurant/templates/about.haml
@@ -45,7 +45,7 @@
           %li
             Android : il suffit de <a href="{{ ANDROID_APP_URL }}">l'installer via Play Store</a>.
           %li
-            iPhone : ajoutez le site à votre écran d'accueil <a href="http://www.apple.com/chfr/ios/add-to-home-screen/">comme expliqué ici</a>.
+            iPhone : ajoutez le site à votre écran d'accueil <a href="https://www.apple.com/chfr/ios/add-to-home-screen/">comme expliqué ici</a>.
           %li
             Windows Phone : épinglez le site sur l'écran d'accueil <a href="http://www.windowsphone.com/fr-be/how-to/wp7/start/pin-things-to-start">comme expliqué ici</a>.
 
@@ -55,13 +55,13 @@
 
       %h3 Quelle est la différence entre Manger Veggie et VegOresto ?
       %p
-        <a href="http://vegoresto.fr/">VegOresto</a>
+        <a href="https://vegoresto.fr/">VegOresto</a>
         recense les restaurants français proposant au moins une entrée, un plat et un dessert végétalien.
-        De son côté, <a href="http://manger-veggie.be">Manger Veggie</a> a pour but de suggérer les restaurants belges
+        De son côté, <a href="https://manger-veggie.be">Manger Veggie</a> a pour but de suggérer les restaurants belges
         proposant des plats végétariens et/ou végétaliens de qualité. Les critiques mises en ligne se concentrent sur les options vg du restaurant.
 
       %p
-        Toutefois, nous sommes en étroite collaboration avec l'équipe de <a href="http://vegoresto.fr/">VegOresto</a>,
+        Toutefois, nous sommes en étroite collaboration avec l'équipe de <a href="https://vegoresto.fr/">VegOresto</a>,
         celle-ci utilisant notre logiciel pour sa <a href="http://m.vegoresto.fr/"/>version mobile</a>.
 
       %h3
@@ -78,7 +78,7 @@
         %a{href: "https://github.com/gdesmott/manger-veggie/"} libre et open-source
         de l'association <a href="http://vegetik.org/">Végétik</a>,
         en partenariat avec
-        %a{href: "http://vegoresto.fr/"} VegOresto
+        %a{href: "https://vegoresto.fr/"} VegOresto
         de l'association <a href="http://www.l214.com/">L214</a>.
 
       .row
@@ -86,11 +86,11 @@
           %a{href: "http://vegetik.org/"}
             %img.img-responsive.about-logo{src:"{{ STATIC_URL }}img/vegetik.png"}
         .col-md-2
-          %a{href: "http://manger-veggie.be/"}
+          %a{href: "https://manger-veggie.be/"}
             %img.img-responsive.about-logo{src:"{{ STATIC_URL }}img/logo-highicon.png"}
         .col-md-2
           %a{href: "http://www.l214.com/"}
             %img.img-responsive.about-logo{src:"{{ STATIC_URL }}img/logo-L214-fond-blanc-carre-100x106.png"}
         .col-md-2
-          %a{href: "http://vegoresto.fr/"}
+          %a{href: "https://vegoresto.fr/"}
             %img.img-responsive.about-logo{src:"{{ STATIC_URL }}img/logo-vegoresto-01.png"}

--- a/vegoresto/templates/about.haml
+++ b/vegoresto/templates/about.haml
@@ -25,7 +25,7 @@
         Les établissements de restauration référencés par <span style="font-family: Olivier">VegOresto</span> proposent au moins un menu vegan à leur carte.
         Les restaurateurs s'y sont engagés en signant la charte <span style="font-family: Olivier">VegOresto</span>.<br/>
         <span style="font-family: Olivier">VegOresto</span> est une initiative de l'organisation de défense des animaux <a href="http://www.l214.com/">L214</a>.<br/>
-        %a{href:"http://vegoresto.fr"} Rendez-vous sur vegoresto.fr pour en savoir plus.
+        %a{href:"https://vegoresto.fr"} Rendez-vous sur vegoresto.fr pour en savoir plus.
 
       %h3#mobile_shortcut Comment installer l'application <span style="font-family: Olivier">VegOresto</span> sur votre smartphone Android ?
       %p
@@ -37,7 +37,7 @@
       %p
         %ul
           %li
-            %a{href:"http://www.apple.com/chfr/ios/add-to-home-screen/"} iPhone/iOS
+            %a{href:"https://www.apple.com/chfr/ios/add-to-home-screen/"} iPhone/iOS
             %ul
               %li Touchez le bouton Partager au bas de l'écran Safari
               %li Touchez l'icône intitulée "Sur l'écran d'accueil"


### PR DESCRIPTION
Some other websites as well. Let's switch.

More over vegoresto.fr ``/resto/<name>`` URL are obsoleted.
Rather use the ``/<name>`` although ideally it should be ``/<city>/<name>``