### PR TITLE
vegoresto: use vgo_url as the absolute URL

### DIFF
--- a/restaurant/management/commands/import-vegoresto.py
+++ b/restaurant/management/commands/import-vegoresto.py
@@ -87,7 +87,7 @@ class Command(BaseCommand):
                 resto.mail = resto_data.mel_public.text
                 resto.main_image = resto_data.image.text
                 resto.country_code = resto_data.pays.text.upper()
-                resto.vegoresto_url = resto_data.vego_url.text
+                resto.vegoresto_url = resto_data.vgo_url.text
                 if resto_data.vegoresto.text == '1':
                     resto.vegoresto = True
                 else:

--- a/restaurant/models.py
+++ b/restaurant/models.py
@@ -9,11 +9,9 @@ from geopy.geocoders import ArcGIS, OpenMapQuest, GoogleV3, Nominatim, GeocoderD
 
 GEOCODERS = [Nominatim, GoogleV3, ArcGIS, OpenMapQuest, GeocoderDotUS]
 
-VEGO_RESTO_URL = "https://vegoresto.fr/%s"
-
 class Restaurant(models.Model):
     vegoresto_id = models.BigIntegerField(unique=True)
-    vegoresto_url = models.TextField(null=True)
+    vegoresto_url = models.URLField(null=True, blank=True)
     # True if the restaurant should appear on VegoResto
     vegoresto = models.BooleanField(default=False)
 
@@ -92,7 +90,7 @@ class Restaurant(models.Model):
 
     def get_absolute_url(self):
         if settings.VEGO_RESTO:
-            return VEGO_RESTO_URL % self.vegoresto_url
+            return self.vegoresto_url
 
         return reverse('restaurant_detail', args=[str(self.id)])
 


### PR DESCRIPTION
vegoresto: use vgo_url as the absolute URL rather than building it from vego_url

Note that they just got renamed:
```
<vego_url> -> <vgo_slug> (more correct)
<link>     -> <vgo_url>  (link is a somehow reserved and .link.text can't be accessed by the importer)
```
