### PR TITLE
define markers_cluster before using it

### DIFF
--- a/restaurant/static/js/map.js
+++ b/restaurant/static/js/map.js
@@ -28,6 +28,8 @@ function display_closest_restaurant () {
 
 function map_init (map, options) {
     global_map = map;
+    // markercluster
+    var markers_cluster = new L.MarkerClusterGroup({ disableClusteringAtZoom: 17 });
 
     if(global_layer != null && map.hasLayer(global_layer))
       global_map.removeLayer(global_layer);
@@ -67,8 +69,6 @@ function map_init (map, options) {
     var lc = L.control.locate({ 'setView': false }).addTo(map);
     lc.locate();
 
-    // markercluster
-    var markers_cluster = new L.MarkerClusterGroup({ disableClusteringAtZoom: 17 });
     global_layer = markers_cluster;
     map.addLayer(markers_cluster);
 }


### PR DESCRIPTION
markers_cluster is used by the JSON callback function.
We received by email the following report (Firefox 54 only):
> TypeError: markers_cluster is undefined sur map.js ligne 54

Although we don't have a reproducer, from a code perspective it may
possible if the JSON is returned quickly enough (ex: cached).
Moving markers_cluster definition earlier should make us safe against such a case.

NB: wasn't able to test it (`python manage.py runserver` threw me an error)